### PR TITLE
Fix metrics controller and add tests

### DIFF
--- a/app/controllers/healthchecker/metrics_controller.rb
+++ b/app/controllers/healthchecker/metrics_controller.rb
@@ -25,6 +25,8 @@ module Healthchecker
     end
 
     module ConfigurableMetrics
+      extend self
+
       def redis
         {
           redis: {

--- a/spec/controllers/metrics_controller_spec.rb
+++ b/spec/controllers/metrics_controller_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe Healthchecker::MetricsController do
+  describe '#current_status' do
+    let(:generic_payload) do
+      { ok: true, config: { foo: 'baz' } }
+    end
+    let(:redis) do
+      { redis: generic_payload }
+    end
+    let(:resque) do
+      { resque_redis: generic_payload }
+    end
+    let(:sidekiq) do
+      { sidekiq_redis: generic_payload }
+    end
+
+    before do
+      allow(Healthchecker::MetricsController::ConfigurableMetrics).to receive(:redis).and_return(redis)
+      allow(Healthchecker::MetricsController::ConfigurableMetrics).to receive(:resque).and_return(resque)
+      allow(Healthchecker::MetricsController::ConfigurableMetrics).to receive(:sidekiq).and_return(sidekiq)
+    end
+
+    context 'when default configuration for metrics' do
+      it 'should show default metrics' do
+        status = Healthchecker::MetricsController.new.current_status
+        expect(status).to include(redis, resque)
+        expect(status).not_to include(sidekiq)
+      end
+    end
+
+    context 'when custom configuration for metrics' do
+      before do
+        Healthchecker.configure do |config|
+          config.metrics = [:redis, :sidekiq]
+        end
+      end
+
+      it 'should show configured metrics' do
+        status = Healthchecker::MetricsController.new.current_status
+        expect(status).to include(redis, sidekiq)
+        expect(status).not_to include(resque)
+      end
+
+      after do
+        Healthchecker.reset
+      end
+    end
+
+    context 'when metrics configured with empty array []' do
+      before do
+        Healthchecker.configure do |config|
+          config.metrics = []
+        end
+      end
+
+      it 'should show only uptime' do
+        status = Healthchecker::MetricsController.new.current_status
+        expect(status).to include(:uptime)
+        expect(status).not_to include(redis, resque, sidekiq)
+      end
+
+      after do
+        Healthchecker.reset
+      end
+    end
+  end
+end


### PR DESCRIPTION
I break it. I fix it.

ConfigurableMetrics module needed to extend self to be able to dynamically call instance methods.